### PR TITLE
Fix ambient context error when calling a member function with hc attribute inside a GridLaunch kernel

### DIFF
--- a/lib/Sema/SemaExprMember.cpp
+++ b/lib/Sema/SemaExprMember.cpp
@@ -1070,7 +1070,7 @@ Sema::BuildMemberReferenceExpr(Expr *BaseExpr, QualType BaseExprType,
       std::string name;
       if(getCurFunctionDecl()) {
         ParentCPU = getCurFunctionDecl()->hasAttr<CXXAMPRestrictCPUAttr>();
-        ParentAMP = getCurFunctionDecl()->hasAttr<CXXAMPRestrictAMPAttr>();
+        ParentAMP = getCurFunctionDecl()->hasAttr<CXXAMPRestrictAMPAttr>() || getCurFunctionDecl()->hasAttr<HCGridLaunchAttr>();
         name = getCurFunctionDecl()->getNameAsString();
       }
       if(ParentCPU || ParentAMP) {


### PR DESCRIPTION
See: https://github.com/GPUOpen-ProfessionalCompute-Tools/HIP/issues/24

Test cases are part of the pull request on the hcc repository.