### PR TITLE
Support [[ hc_grid_launch ]] CXX11-style attribute syntax.

### DIFF
--- a/include/clang/Basic/Attr.td
+++ b/include/clang/Basic/Attr.td
@@ -1908,7 +1908,7 @@ def CXXAMPRestrictCPU : InheritableAttr {
 }
 
 def HCGridLaunch : InheritableAttr {
-  let Spellings = [GNU<"hc_grid_launch">];
+  let Spellings = [GNU<"hc_grid_launch">, CXX11<"", "hc_grid_launch">];
   let Subjects = SubjectList<[Function]>;
   let Documentation = [Undocumented];
 }


### PR DESCRIPTION
Test for this new syntax coming in a separate commit.
Errors shown below are also present on Develop branch before changes.


bensander@hcSWAP-AUS-Fiji1:~/HCC/build.hack_gl$ HCC_RUNTIME=HSA make test
Scanning dependencies of target test
[100%] Running HCC regression tests
llvm-lit: lit.cfg:115: note: using clang: '/home/bensander/HCC/build.hack_gl/compiler/bin/clang'
FAIL: CPPAMP :: Unit/AmpShortVectors/hc_short_vector_device.cpp (166 of 711)
******************** TEST 'CPPAMP :: Unit/AmpShortVectors/hc_short_vector_device.cpp' FAILED ********************
Script:
--
/home/bensander/HCC/build.hack_gl/compiler/bin/clang++ -I/home/bensander/HCC/src.hack_gl/utils -IOPENCL_HEADER-NOTFOUND/../ -DGTEST_HAS_TR1_TUPLE=0 -stdlib=libc++  -std=c++amp -stdlib=libc++ -I/home/bensander/HCC/src.hack_gl/include -hc  -std=c++amp -L/home/bensander/HCC/build.hack_gl/lib -Wl,--rpath=/home/bensander/HCC/build.hack_gl/lib -lc++ -lc++abi -ldl -lpthread -Wl,--whole-archive -lmcwamp -Wl,--no-whole-archive  -lpthread  /home/bensander/HCC/src.hack_gl/tests/Unit/AmpShortVectors/hc_short_vector_device.cpp -o /home/bensander/HCC/build.hack_gl/tests/Unit/AmpShortVectors/Output/hc_short_vector_device.cpp.tmp.out && /home/bensander/HCC/build.hack_gl/tests/Unit/AmpShortVectors/Output/hc_short_vector_device.cpp.tmp.out
--
Exit Code: 1


********************
FAIL: CPPAMP :: Unit/GridLaunch/customtype_byval.cpp (382 of 711)
******************** TEST 'CPPAMP :: Unit/GridLaunch/customtype_byval.cpp' FAILED ********************
Script:
--
/home/bensander/HCC/build.hack_gl/compiler/bin/clang++ -I/home/bensander/HCC/src.hack_gl/utils -IOPENCL_HEADER-NOTFOUND/../ -DGTEST_HAS_TR1_TUPLE=0 -stdlib=libc++  -std=c++amp -stdlib=libc++ -I/home/bensander/HCC/src.hack_gl/include -hc  -std=c++amp -L/home/bensander/HCC/build.hack_gl/lib -Wl,--rpath=/home/bensander/HCC/build.hack_gl/lib -lc++ -lc++abi -ldl -lpthread -Wl,--whole-archive -lmcwamp -Wl,--no-whole-archive  -lpthread  -lhc_am /home/bensander/HCC/src.hack_gl/tests/Unit/GridLaunch/customtype_byval.cpp -o /home/bensander/HCC/build.hack_gl/tests/Unit/GridLaunch/Output/customtype_byval.cpp.tmp.out && /home/bensander/HCC/build.hack_gl/tests/Unit/GridLaunch/Output/customtype_byval.cpp.tmp.out
--
Exit Code: 1

Command Output (stderr):
--
/home/bensander/HCC/src.hack_gl/tests/Unit/GridLaunch/customtype_byval.cpp:43:18: error:  'Foo::getY':  no overloaded function has restriction specifiers that are compatible with the ambient context 'kernel1'
  y[i].x = i + x.getY();
                 ^
1 error generated.

--

********************
Testing Time: 279.34s
********************
Failing Tests (2):
    CPPAMP :: Unit/AmpShortVectors/hc_short_vector_device.cpp
    CPPAMP :: Unit/GridLaunch/customtype_byval.cpp

  Expected Passes    : 674
  Expected Failures  : 25
  Unsupported Tests  : 10
  Unexpected Failures: 2